### PR TITLE
Add support for additional entity states

### DIFF
--- a/custom_components/joule_connector/climate.py
+++ b/custom_components/joule_connector/climate.py
@@ -118,10 +118,21 @@ class JouleThermostat(
 
         Returns
         -------
-            The current temperature in a float format..
+            The current temperature in a float format.
 
         """
         return self.coordinator.data[self.idx].get_current_temperature() / 100
+    
+    @property
+    def current_humidity(self) -> float:
+        """Return current humidity.
+
+        Returns
+        -------
+            The current humidity in a float format.
+
+        """
+        return self.coordinator.data[self.idx].humidity
 
     @property
     def target_temperature(self) -> float:

--- a/custom_components/joule_connector/joule_api.py
+++ b/custom_components/joule_connector/joule_api.py
@@ -29,6 +29,7 @@ class Thermostat:
     online: bool
     heating: bool | None
     temperature: int = 0
+    humidity: int = 0
     set_point_temperature: int = 0
     regulation_mode: int = 0
     supported_regulation_modes: list[int] = field(default_factory=list)
@@ -100,6 +101,7 @@ class Thermostat:
         """Return a new Thermostat instance based on JSON from the JCC History API."""
         thermostat.set_point_temperature = int(data["room_setpoint"]["data"][0]["value"]) * 100
         thermostat.temperature = int(data["ambient_temperature"]["data"][0]["value"]) * 100
+        thermostat.humidity = int(data["ambient_humidity"]["data"][0]["value"])
         thermostat.name = thermostat.name + " " + thermostat.serial_number
         if "flame_state" in data:
             thermostat.heating = bool(data["flame_state"]["data"][0]["value"])

--- a/custom_components/joule_connector/joule_api.py
+++ b/custom_components/joule_connector/joule_api.py
@@ -101,7 +101,8 @@ class Thermostat:
         thermostat.set_point_temperature = int(data["room_setpoint"]["data"][0]["value"]) * 100
         thermostat.temperature = int(data["ambient_temperature"]["data"][0]["value"]) * 100
         thermostat.name = thermostat.name + " " + thermostat.serial_number
-
+        if "flame_state" in data:
+            thermostat.heating = bool(data["flame_state"]["data"][0]["value"])
 
         return thermostat
         


### PR DESCRIPTION
Added support for hvac_action and humidity attributes of the climate entity.

Having a working hvac_action makes this visible in the history graph as well:
![image](https://github.com/user-attachments/assets/b949d2d2-e891-46e7-8385-8f977dc7050c)
